### PR TITLE
CORE-7635 Add notary support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,5 +84,4 @@ GroupPolicy.json
 CordaPID.dat
 *.pem
 *.pfx
-CPIFileStatus.json
-
+CPIFileStatus*.json

--- a/build.gradle
+++ b/build.gradle
@@ -149,6 +149,9 @@ dependencies {
     // Not yet fully implemented:
     // cordaProvided 'net.corda:corda-ledger'
 
+    // CorDapps that use the UTXO ledger must include at least one notary client plugin
+    cordapp "com.r3.corda.notary.plugin.nonvalidating:notary-plugin-non-validating-client:$cordaNotaryPluginsVersion"
+
     // The CorDapp uses the slf4j logging framework. Corda-API provides this so we need a 'cordaProvided' declaration.
     cordaProvided 'org.slf4j:slf4j-api'
 

--- a/buildSrc/src/main/groovy/csde.gradle
+++ b/buildSrc/src/main/groovy/csde.gradle
@@ -18,12 +18,23 @@ configurations {
         canBeResolved = true
     }
 
+    notaryServerCPB {
+        canBeConsumed = false
+        canBeResolved = true
+    }
 }
 
 // Dependencies for supporting tools
 dependencies {
     combinedWorker "net.corda:corda-combined-worker:$combinedWorkerVersion"
     myPostgresJDBC 'org.postgresql:postgresql:42.4.1'
+    notaryServerCPB("com.r3.corda.notary.plugin.nonvalidating:notary-plugin-non-validating-server:$cordaNotaryPluginsVersion") {
+        artifact {
+            classifier = 'package'
+            extension = 'cpb'
+        }
+    }
+
     implementation "org.codehaus.groovy:groovy-json:3.0.9"
 }
 
@@ -33,6 +44,7 @@ def pluginImplGroupName = "other"
 def cordaBinDir= System.getProperty('user.home') + "/.corda/corda5"
 def cordaCliBinDir = System.getProperty('user.home') + "/.corda/cli"
 def cordaJDBCDir = cordaBinDir + "/jdbcDrivers"
+def cordaNotaryServerDir = System.getProperty('user.home') + "/.corda/notaryserver"
 def signingCertAlias="gradle-plugin-default-key"
 // Get error if this is not a autotyped object
 // def signingCertFName = "$rootDir/config/gradle-plugin-default-key.pem"
@@ -44,7 +56,8 @@ def combiWorkerPidCacheFile = devEnvWorkspace + "/CordaPID.dat"
 
 
 // Need to read things from cordapp plugin
-def cpiName =  'cpi name'
+def appCpiName =  'cpi name'
+def notaryCpiName =  'CSDE Notary Server CPI'
 
 def csdeHelper = new CsdeRpcInterface(project,
         cordaClusterURL.toString(),
@@ -119,6 +132,12 @@ tasks.register("getDevCordaLite", Copy) {
     into cordaBinDir
 }
 
+tasks.register("getNotaryServerCPB", Copy) {
+    group = pluginImplGroupName
+    from configurations.notaryServerCPB
+    into cordaNotaryServerDir
+}
+
 tasks.register('createKeystore') {
     group = pluginImplGroupName
     dependsOn('projInit')
@@ -162,29 +181,54 @@ tasks.register('createKeystore') {
 }
 
 
-tasks.register('buildCPI') {
+tasks.register('buildCPIs') {
     group = pluginGroupName
-    dependsOn('build', 'createGroupPolicy', 'createKeystore')
+    dependsOn('build', 'createGroupPolicy', 'createKeystore', 'getNotaryServerCPB')
 
     doLast{
-        def cpiFile= buildDir.toString() + "/" + project.archivesBaseName + "-" + project.version + ".cpi"
-        delete { delete cpiFile }
+        // Application CPI
+        def appCpiFile = buildDir.toString() + "/" + project.archivesBaseName + "-" + project.version + ".cpi"
+        delete { delete appCpiFile }
         File srcDir
         srcDir = file('build/libs')
 
         // Create a file collection using a closure
-        def collection = layout.files { srcDir.listFiles() }
-        def cpbs = collection.filter { it.getName().endsWith(".cpb") }
+        def appCollection = layout.files { srcDir.listFiles() }
+        def appCpbs = appCollection.filter { it.getName().endsWith(".cpb") }
 
         javaexec {
             classpath = files("$cordaCliBinDir/corda-cli.jar")
             jvmArgs = ["-Dpf4j.pluginsDir=$cordaCliBinDir/plugins/"]
             args = ['package', 'create-cpi',
-                    '--cpb', cpbs.singleFile.absolutePath,
+                    '--cpb', appCpbs.singleFile.absolutePath,
                     '--group-policy', "${devEnvWorkspace}/GroupPolicy.json",
-                    '--cpi-name', cpiName,
+                    '--cpi-name', appCpiName,
                     '--cpi-version', project.version,
-                    '--file', cpiFile,
+                    '--file', appCpiFile,
+                    '--keystore', "${devEnvWorkspace}/signingkeys.pfx",
+                    '--storepass', 'keystore password',
+                    '--key', 'my-signing-key' ]
+        }
+
+        // Notary CPI
+        def notaryCpiFile = buildDir.toString() + "/" +
+                notaryCpiName.replace(' ', '-').toLowerCase() + "-" + project.version + ".cpi"
+        delete { delete notaryCpiFile }
+
+        // Create a file collection using a closure
+        def notaryCpbs = layout
+                .files { file(cordaNotaryServerDir).listFiles() }
+                .filter { it.getName().endsWith(".cpb") }
+
+        javaexec {
+            classpath = files("$cordaCliBinDir/corda-cli.jar")
+            jvmArgs = ["-Dpf4j.pluginsDir=$cordaCliBinDir/plugins/"]
+            args = ['package', 'create-cpi',
+                    '--cpb', notaryCpbs.singleFile.absolutePath,
+                    '--group-policy', "${devEnvWorkspace}/GroupPolicy.json",
+                    '--cpi-name', notaryCpiName,
+                    '--cpi-version', project.version,
+                    '--file', notaryCpiFile,
                     '--keystore', "${devEnvWorkspace}/signingkeys.pfx",
                     '--storepass', 'keystore password',
                     '--key', 'my-signing-key' ]
@@ -193,19 +237,24 @@ tasks.register('buildCPI') {
 
 }
 
-tasks.register("deployCPI") {
+tasks.register("deployCPIs") {
     group = pluginImplGroupName
-    dependsOn('buildCPI')
+    dependsOn('buildCPIs')
     doLast {
         csdeHelper.uploadCertificate(signingCertAlias, signingCertFName)
         csdeHelper.uploadCertificate(keystoreAlias, keystoreCertFName)
-        csdeHelper.deployCPI("${buildDir}/${project.archivesBaseName}-${project.version}.cpi", cpiName, project.version)
+        csdeHelper.deployCPI("${buildDir}/${project.archivesBaseName}-${project.version}.cpi", appCpiName, project.version)
+        csdeHelper.deployCPI(
+                "${buildDir}/${notaryCpiName.replace(' ', '-').toLowerCase()}-${project.version}.cpi",
+                notaryCpiName,
+                project.version,
+                "-NotaryServer")
     }
 }
 
 tasks.register("createAndRegVNodes") {
     group = pluginImplGroupName
-    dependsOn('deployCPI')
+    dependsOn('deployCPIs')
     doLast {
         csdeHelper.createAndRegVNodes()
     }
@@ -246,6 +295,3 @@ tasks.register("stopCorda") {
         csdeHelper.stopCorda()
     }
 }
-
-
-

--- a/buildSrc/src/main/java/com/r3/csde/CsdeRpcInterface.java
+++ b/buildSrc/src/main/java/com/r3/csde/CsdeRpcInterface.java
@@ -104,14 +104,26 @@ public class CsdeRpcInterface {
 
                 String svcX500Id = jsonNodeToString(notary.get("serviceX500Name"));
 
-                for (com.fasterxml.jackson.databind.JsonNode representative : notary.get("representatives")) {
+                com.fasterxml.jackson.databind.JsonNode repsForThisService = notary.get("representatives");
+
+                if (repsForThisService.isEmpty()) {
+                    throw new ConfigurationException(
+                            "Notary service \"" + svcX500Id + "\" must have at least one representative.");
+                } else if (repsForThisService.size() > 1) {
+                    // Temporary restriction while the MGM only supports a 1-1 association
+                    throw new ConfigurationException(
+                            "Notary service \"" + svcX500Id + "\" can only have a single representative at this time.");
+                }
+
+                for (com.fasterxml.jackson.databind.JsonNode representative : repsForThisService) {
 
                     String repAsString = jsonNodeToString(representative);
 
                     if (identities.contains(repAsString)) {
                         notaryRepresentatives.put(repAsString, svcX500Id);
                     } else {
-                        throw new ConfigurationException("Notary representative \"" + repAsString + "\" is not a valid identity");
+                        throw new ConfigurationException(
+                                "Notary representative \"" + repAsString + "\" is not a valid identity");
                     }
                 }
             }

--- a/config/dev-net.json
+++ b/config/dev-net.json
@@ -2,6 +2,11 @@
 "identities" : [
  "CN=Alice, OU=Test Dept, O=R3, L=London, C=GB",
  "CN=Bob, OU=Test Dept, O=R3, L=London, C=GB",
- "CN=Charlie, OU=Test Dept, O=R3, L=London, C=GB"
- ]
+ "CN=Charlie, OU=Test Dept, O=R3, L=London, C=GB",
+ "CN=NotaryRep1, OU=Test Dept, O=R3, L=London, C=GB"],
+"notaries" : [
+ {
+  "serviceX500Name": "CN=NotaryService, OU=Test Dept, O=R3, L=London, C=GB",
+  "representatives": ["CN=NotaryRep1, OU=Test Dept, O=R3, L=London, C=GB"]
+ }]
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,6 +4,10 @@ kotlin.code.style=official
 # This needs to match the version supported by the Corda Cluster the CorDapp will run on.
 cordaApiVersion=5.0.0.500-beta+
 
+# Specify the version of the notary plugins to use.
+# Currently packaged as part of corda-runtime-os, so should be set to a corda-runtime-os version.
+cordaNotaryPluginsVersion=5.0.0.0-SNAPSHOT
+
 # Specify the version of the cordapp-cpb and cordapp-cpk plugins
 cordaPluginsVersion=7.0.0-SNAPSHOT
 


### PR DESCRIPTION
### Summary
This PR adds notary support to the CSDE environment. A notary is required for any CorDapp using the UTXO ledger, which is considered to be the common case.

Notaries are defined via a new `notaries` item in the `dev-net.json` file. This takes a list of notaries. Each notary must specify a `serviceX500Name`, which is the name that will be used by the application CorDapp when requesting notarisation. Further, a list of `representatives` must be specified, which refer to virtual nodes defined in the existing `identities` block. Each notary must have at least one representative. An artificial limitation is currently enforced to further restrict this to exactly one representative, until such a time as the MGM supports many representatives for a single notary service. The shipped configuration defines a single notary service, with a single representative.

Other changes that have been made in this PR to support notaries are:

- The CSDE application has included the non-validating notary client as a `cordapp` dependency. This also transitively pulls in the non-validating notary API, and notary common CPKs, and includes these when creating the application CPB.
- `deployCordapp` will now only install the CSDE application CPI on non-notary representative virtual nodes. Notary representative virtual nodes instead have a non-validating notary server CPI installed, which is produced by downloading a standard non-validating notary server CPB and building a corresponding CPI as part of `deployCordapp`
- `listVNodes` now also shows the CPI name installed on each virtual node, making it easy to see at a glance which virtual nodes are notary representatives.
- The virtual node creation and network registration steps in `deployCordapp` are now executed asynchronously. This significantly reduces the task execution time.

### Testing
- Network configuration:
  -  Ensured that new baseline configuration in `dev-net.json` is successfully deployed. Asynchronous Vnode creation and network registration calls reduced execution time of `deployCordapp` task from 110-120 seconds to 50-60s (around a 60s saving).
  - Checked that it is possible to deploy multiple notaries on the network
  - Checked that task fails if a notary service is defined with no representatives, or has multiple representatives
  - When using the new baseline configuration, confirmed that the notary representative has the following additional `memberContext fields in the MGM:
```
       "corda.notary.service.name": "CN=NotaryService, OU=Test Dept, O=R3, L=London, C=GB",
       "corda.notary.service.plugin": "corda.notary.type.nonvalidating"
       "corda.roles.0": "notary"
```
- Notary client CPK bundling, application CPI:
  - Used the `GET` `cpi` endpoint to confirm that the CSDE "application" CPI contains the notary common, non-validating notary API and non-validating notary client CPKs. Also confirmed that the CSDE "application" CPK bundled in this CPI lists the notary CPKs as dependencies.
  - Ensured that only "application" (i.e. non-notary virtual nodes) use the application CPI
- Notary server CPB download, CPI creation and upload:
  - Ensured that notary server CPB is successfully downloaded, and new CPI constructed
  - Ensured that only notary virtual nodes use the notary server CPI
- `listVNodes` task:
  - Checked that returned results now show the CPI name appropriately, based on the nodes role. For the new baseline configuration, this looks something like:
```
        > Task :listVNodes
        X500 Name	Holding identity short hash	CPI Name
        "CN=Alice, OU=Test Dept, O=R3, L=London, C=GB"	"3904C26AA40F"	"cpi name"
        "CN=Bob, OU=Test Dept, O=R3, L=London, C=GB"	"1A58A6142AF2"	"cpi name"
        "CN=NotaryRep1, OU=Test Dept, O=R3, L=London, C=GB"	"7851964E0D7E"	"CSDE Notary Server CPI"
        "CN=Charlie, OU=Test Dept, O=R3, L=London, C=GB"	"066D6787724E"	"cpi name"
```