### PR TITLE
NOTICK: Capture CPI build errors

### DIFF
--- a/buildSrc/src/main/java/com/r3/csde/BuildCPIsHelper.java
+++ b/buildSrc/src/main/java/com/r3/csde/BuildCPIsHelper.java
@@ -197,18 +197,10 @@ public class BuildCPIsHelper {
         Process proc = pb.start();
         proc.waitFor();
 
-// todo: work out how to capture error code better than the following code
-
-//        BufferedReader reader = new BufferedReader(new InputStreamReader(proc.getInputStream()));
-//        File tempOutputFile = new File(String.format("%s/tempOutput.txt", pc.devEnvWorkspace));
-//        tempOutputFile.delete();
-//        FileWriter fileWriter = new FileWriter(tempOutputFile);
-//        String line;
-//        while (( line = reader.readLine()) != null){
-//            fileWriter.write(line + "\n");
-//        }
-//        fileWriter.close();
-
+        //Get CPI packaging errors
+        if (proc.getErrorStream().available() > 0) {
+            proc.getErrorStream().transferTo(pc.out);
+        }
     }
 
     private void createNotaryCPI() throws CsdeException, IOException, InterruptedException {


### PR DESCRIPTION
I hit an error building a CPI. This PR replaces the `TODO` by transferring the error stream and failing the build