### PR TITLE
Core 9204 change exception type

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Note: This cut of CSDE is work in progress and has not been released yet, hence may not function as expected.
 
 
-To help make the process of prototyping Cordapps on Corda 5 beta 1 release more straight forward we have developed the Cordapp Standard Development Environment (CSDE). 
+To help make the process of prototyping CorDapps on Corda 5 beta 1.1 release more straight forward we have developed the Cordapp Standard Development Environment (CSDE). 
 
 The CSDE is obtained by cloning this CSDE-Cordapp-Template-Kotlin to your local machine. The CSDE provides:
 
@@ -24,3 +24,6 @@ The CSDE is obtained by cloning this CSDE-Cordapp-Template-Kotlin to your local 
 Note, the CSDE is experimental, we may or may not release it as part of Corda 5.0, in part based on developer feedback using it.  
 
 To find out how to use the CSDE please refer to the getting started section in the Corda 5 Beta 1 documentation at https://docs.r3.com/ (documentation not completed yet for beta 1)
+
+
+

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The CSDE is obtained by cloning this CSDE-Cordapp-Template-Kotlin to your local 
 
 Note, the CSDE is experimental, we may or may not release it as part of Corda 5.0, in part based on developer feedback using it.  
 
-To find out how to use the CSDE please refer to the getting started section in the Corda 5 Beta 1 documentation at https://docs.r3.com/ (documentation not completed yet for beta 1)
+To find out how to use the CSDE please refer to the getting started section in the Corda 5 Beta 1.1 documentation at https://docs.r3.com/ (documentation not completed yet for beta 1.1)
 
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,6 @@ plugins {
 }
 
 allprojects {
-    // todo: this needs changing - need to check what impact it has.
     group 'com.r3.developers.csdetemplate'
     version '1.0-SNAPSHOT'
 

--- a/contracts/src/main/kotlin/com/r3/developers/csdetemplate/utxoexample/contracts/ChatContract.kt
+++ b/contracts/src/main/kotlin/com/r3/developers/csdetemplate/utxoexample/contracts/ChatContract.kt
@@ -1,6 +1,7 @@
 package com.r3.developers.csdetemplate.utxoexample.contracts
 
 import com.r3.developers.csdetemplate.utxoexample.states.ChatState
+import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.ledger.utxo.Command
 import net.corda.v5.ledger.utxo.Contract
 import net.corda.v5.ledger.utxo.transaction.UtxoLedgerTransaction
@@ -16,7 +17,7 @@ class ChatContract: Contract {
     override fun verify(transaction: UtxoLedgerTransaction) {
 
         // Ensures that there is only one command in the transaction
-        val command = transaction.commands.singleOrNull() ?: throw Exception("Require a single command ")
+        val command = transaction.commands.singleOrNull() ?: throw CordaRuntimeException("Require a single command ")
 
         // Applies a universal constraint (applies to all transactions irrespective of command)
         "The output state should have two and only two participants" using {

--- a/workflows/src/main/kotlin/com/r3/developers/csdetemplate/utxoexample/workflows/CreateNewChatFlow.kt
+++ b/workflows/src/main/kotlin/com/r3/developers/csdetemplate/utxoexample/workflows/CreateNewChatFlow.kt
@@ -6,6 +6,7 @@ import net.corda.v5.application.flows.*
 import net.corda.v5.application.marshalling.JsonMarshallingService
 import net.corda.v5.application.membership.MemberLookup
 import net.corda.v5.base.annotations.Suspendable
+import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.days
@@ -52,8 +53,12 @@ class CreateNewChatFlow: RPCStartableFlow {
             val flowArgs = requestBody.getRequestBodyAs(jsonMarshallingService, CreateNewChatFlowArgs::class.java)
 
             // Get MemberInfos for the Vnode running the flow and the otherMember.
+            // Good practice in Kotlin CorDapps is to only throw RuntimeException.
+            // Note, in Java CorDapps only unchecked RuntimeExceptions can be thrown not
+            // declared checked exceptions as this changes the method signature and breaks override.
             val myInfo = memberLookup.myInfo()
-            val otherMember = memberLookup.lookup(MemberX500Name.parse(flowArgs.otherMember)) ?: throw IllegalArgumentException("can't find other member")
+            val otherMember = memberLookup.lookup(MemberX500Name.parse(flowArgs.otherMember)) ?:
+                throw CordaRuntimeException("MemberLookup can't find otherMember specified in flow arguments ")
 
             // Create the ChatState from the input arguments and member information.
             val chatState = ChatState(

--- a/workflows/src/main/kotlin/com/r3/developers/csdetemplate/utxoexample/workflows/FinalizeChatSubFlow.kt
+++ b/workflows/src/main/kotlin/com/r3/developers/csdetemplate/utxoexample/workflows/FinalizeChatSubFlow.kt
@@ -5,6 +5,7 @@ import net.corda.v5.application.flows.*
 import net.corda.v5.application.messaging.FlowMessaging
 import net.corda.v5.application.messaging.FlowSession
 import net.corda.v5.base.annotations.Suspendable
+import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.base.util.contextLogger
 import net.corda.v5.ledger.utxo.UtxoLedgerService
@@ -79,7 +80,7 @@ class FinalizeChatResponderFlow: ResponderFlow {
 
                 // Note, this exception will only be shown in the logs if Corda Logging is set to debug.
                 val state = ledgerTransaction.getOutputStates<ChatState>().singleOrNull() ?:
-                    throw IllegalStateException("Failed verification - transaction did not have exactly one output ChatState")
+                    throw CordaRuntimeException("Failed verification - transaction did not have exactly one output ChatState")
 
                 // Uses checkForBannedWords() and checkMessageFromMatchesCounterparty() functions
                 // to check whether to sign the transaction.

--- a/workflows/src/main/kotlin/com/r3/developers/csdetemplate/utxoexample/workflows/ResponderValidations.kt
+++ b/workflows/src/main/kotlin/com/r3/developers/csdetemplate/utxoexample/workflows/ResponderValidations.kt
@@ -1,7 +1,9 @@
 package com.r3.developers.csdetemplate.utxoexample.workflows
 
 import com.r3.developers.csdetemplate.utxoexample.states.ChatState
+import net.corda.v5.base.annotations.CordaSerializable
 import net.corda.v5.base.annotations.Suspendable
+import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.base.types.MemberX500Name
 
 // Note, these exceptions will only be visible in the logs if Corda logging is set to debug.
@@ -11,7 +13,7 @@ import net.corda.v5.base.types.MemberX500Name
 fun checkForBannedWords(str: String) {
     val bannedWords = listOf("banana", "apple", "pear")
     if (bannedWords.any { str.contains(it) })
-        throw IllegalStateException("Failed verification - message contains banned words")
+        throw CordaRuntimeException("Failed verification - message contains banned words")
 }
 
 // Checks that the messageFrom field in the ChatState matches the initiators (otherMember)
@@ -19,5 +21,5 @@ fun checkForBannedWords(str: String) {
 @Suspendable
 fun checkMessageFromMatchesCounterparty(state: ChatState, otherMember: MemberX500Name) {
    if( state.messageFrom != otherMember)
-       throw IllegalStateException("Failed verification - messageFrom does not equal flow initiator")
+       throw CordaRuntimeException("Failed verification - messageFrom does not equal flow initiator memberX500Name")
 }

--- a/workflows/src/main/kotlin/com/r3/developers/csdetemplate/utxoexample/workflows/UpdateChatFlow.kt
+++ b/workflows/src/main/kotlin/com/r3/developers/csdetemplate/utxoexample/workflows/UpdateChatFlow.kt
@@ -6,6 +6,7 @@ import net.corda.v5.application.flows.*
 import net.corda.v5.application.marshalling.JsonMarshallingService
 import net.corda.v5.application.membership.MemberLookup
 import net.corda.v5.base.annotations.Suspendable
+import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.days
 import net.corda.v5.ledger.utxo.UtxoLedgerService
@@ -53,16 +54,16 @@ class UpdateChatFlow: RPCStartableFlow {
             // Note, you will get this error if you input an id which has no corresponding ChatState (common error).
             val stateAndRef = ledgerService.findUnconsumedStatesByType(ChatState::class.java).singleOrNull {
                 it.state.contractState.id == flowArgs.id
-            } ?: throw Exception("Multiple or zero Chat states with id ${flowArgs.id} found")
+            } ?: throw CordaRuntimeException("Multiple or zero Chat states with id ${flowArgs.id} found")
 
             // Get MemberInfos for the Vnode running the flow and the otherMember.
             val myInfo = memberLookup.myInfo()
             val state = stateAndRef.state.contractState
 
             val members = state.participants.map {
-                memberLookup.lookup(it) ?: throw Exception("Member not found from Key")}
+                memberLookup.lookup(it) ?: throw CordaRuntimeException("Member not found from public key $it")}
             val otherMember = (members - myInfo).singleOrNull()
-                ?: throw Exception("Should be only one participant other than the initiator")
+                ?: throw CordaRuntimeException("Should be only one participant other than the initiator")
 
             // Create a new ChatState using the updateMessage helper function.
             val newChatState = state.updateMessage(myInfo.name, flowArgs.message)
@@ -100,7 +101,7 @@ RequestBody for triggering the flow via http-rpc:
     "clientRequestId": "update-2",
     "flowClassName": "com.r3.developers.csdetemplate.utxoexample.workflows.UpdateChatFlow",
     "requestData": {
-        "id":"e1e0e45d-1b8f-41df-821f-fe3052784f45",
+        "id":"** fill in id **",
         "message": "How are you today?"
         }
 }


### PR DESCRIPTION
Per conversation in corda-platform, CorDapps should not be throwing checked exceptions, hence changed all exceptions to CordaRuntimeExceptions.

Note, this is because when writing Java Cordapps throwing a checked exception changes the the method signature which interferes with overriding the call() method. 