### PR TITLE
Add an option parameter to the startCorda gradle task

### DIFF
--- a/buildSrc/src/main/groovy/csde.gradle
+++ b/buildSrc/src/main/groovy/csde.gradle
@@ -134,7 +134,11 @@ tasks.register("startCorda") {
     dependsOn('getDevCordaLite', 'getPostgresJDBC')
     doLast {
         mkdir devEnvWorkspace
-        cordaLifeCycle.startCorda()
+        // Default port number to be used by Corda 5 workers
+        // However, note that using port 7000 on macOS may not be able to start the process
+        // because this port is used by AirPlay by default
+        def port = Integer.parseInt(project.findProperty("port") ?: "7000")
+        cordaLifeCycle.startCorda(port)
     }
 }
 

--- a/buildSrc/src/main/java/com/r3/csde/CordaLifeCycleHelper.java
+++ b/buildSrc/src/main/java/com/r3/csde/CordaLifeCycleHelper.java
@@ -21,7 +21,7 @@ public class CordaLifeCycleHelper {
     }
 
 
-    public void startCorda() throws IOException {
+    public void startCorda(Integer port) throws IOException {
         PrintStream pidStore = new PrintStream(new FileOutputStream(pc.cordaPidCache));
         File combinedWorkerJar = pc.project.getConfigurations().getByName("combinedWorker").getSingleFile();
 
@@ -45,6 +45,7 @@ public class CordaLifeCycleHelper {
                 "-jar",
                 combinedWorkerJar.toString(),
                 "--instanceId=0",
+                "-p="+port,
                 "-mbus.busType=DATABASE",
                 "-spassphrase=password",
                 "-ssalt=salt",


### PR DESCRIPTION
As described in the issue https://github.com/corda/CSDE-cordapp-template-kotlin/issues/38, port 7000 is used by AirPlay on macOS by default. In order to run the startCorda task, I have to switch off AirPlay in my system set to make it works.

Thus, I suggest adding an optional parameter in the startCorda gradle task such that we can configure Corda 5 to use another port number to avoid this problem.

We can then add a port number parameter in the gradle task as shown in the below diagram. If this parameter is not supplied, port 7000 is still used by default.

<img width="1152" alt="Screenshot 2023-01-30 at 6 56 19 PM" src="https://user-images.githubusercontent.com/8806412/215458470-f62c24b2-5ab7-41da-a6a4-5d58e45510b9.png">
