### PR TITLE
NOTICK: Capture CPI build errors

### DIFF
--- a/buildSrc/src/main/java/com/r3/csde/BuildCPIsHelper.java
+++ b/buildSrc/src/main/java/com/r3/csde/BuildCPIsHelper.java
@@ -215,6 +215,12 @@ public class BuildCPIsHelper {
 //        }
 //        fileWriter.close();
 
+// todo: in the meantime, here is a simple working impl
+
+        //Get CPI packaging errors
+        if (proc.getErrorStream().available() > 0) {
+            proc.getErrorStream().transferTo(pc.out);
+        }
     }
 
     private void createNotaryCPI() throws CsdeException, IOException, InterruptedException {


### PR DESCRIPTION
This is extracted from https://github.com/corda/CSDE-cordapp-template-kotlin/pull/29

Digital Currencies project and team are using&testing it for the last 3 moths