### PR TITLE
CORE-15561: Use Beta versions of the CSDE gradle plugin

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@ combinedWorkerJarVersion=5.0.0.0-Iguana1.0
 cordaPluginsVersion=7.0.3
 
 # Specify the version of the CSDE gradle plugin to use
-csdePluginVersion=1.2.0-alpha-+
+csdePluginVersion=1.2.0-beta-+
 
 # Specify the name of the workflows module
 workflowsModule=workflows


### PR DESCRIPTION
The CSDE gradle plugin project now creates beta versions from merged code, which will result in more stability over consuming the latest alpha; which are still created for all other branches of the CSDE gradle plugin project.