### PR TITLE
CORE-15572: deleted stale todo comments

### DIFF
--- a/contracts/build.gradle
+++ b/contracts/build.gradle
@@ -39,12 +39,6 @@ dependencies {
     // The CorDapp uses the slf4j logging framework. Corda-API provides this so we need a 'cordaProvided' declaration.
     cordaProvided 'org.slf4j:slf4j-api'
 
-    // This are shared so should be here.
-    // Dependencies Required By Test Tooling
-    // Todo:  these are commented out as the simulator UTXO work has not been merged into Gecko yet.
-//    testImplementation "net.corda:corda-simulator-api:$simulatorVersion"
-//    testRuntimeOnly "net.corda:corda-simulator-runtime:$simulatorVersion"
-
     // 3rd party libraries
     // Required
     testImplementation "org.slf4j:slf4j-simple:2.0.0"

--- a/workflows/build.gradle
+++ b/workflows/build.gradle
@@ -40,18 +40,13 @@ dependencies {
     // The CorDapp uses the slf4j logging framework. Corda-API provides this so we need a 'cordaProvided' declaration.
     cordaProvided 'org.slf4j:slf4j-api'
 
-    // Dependencies Required By Simulator Tests
-    // Todo:  these are commented out as the simulator UTXO work has not been merged into Gecko yet.
-//    testImplementation "net.corda:corda-simulator-api:$simulatorVersion"
-//    testRuntimeOnly "net.corda:corda-simulator-runtime:$simulatorVersion"
-
     // 3rd party libraries
     // Required
     testImplementation "org.slf4j:slf4j-simple:2.0.0"
     testImplementation "org.junit.jupiter:junit-jupiter:$junitVersion"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junitVersion"
 
-    // Optional but used by exmaple tests.
+    // Optional but used by example tests.
     testImplementation "org.mockito:mockito-core:$mockitoVersion"
     testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"
     testImplementation "org.hamcrest:hamcrest-library:$hamcrestVersion"


### PR DESCRIPTION
What
Currently the template repos have comments of plugins that won’t be available anytime soon.


Why:
For the past releases, it has been a repeatable step to get rid of this code for GA.
This is to save time for the following GA release preps