### PR TITLE
CORE-16818: Remove duplicated tasks being invoked

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,6 @@ allprojects {
     def javaVersion = VERSION_17
 
     // Configure the CSDE
-    apply plugin: 'net.corda.plugins.csde'
     csde {
         cordaClusterURL = "https://localhost:8888"
         networkConfigFile = "config/static-network-config.json"

--- a/workflows/build.gradle
+++ b/workflows/build.gradle
@@ -68,7 +68,7 @@ dependencies {
 }
 
 tasks.withType(Test).configureEach {
-    dependsOn('getNotaryServerCPB')
+    dependsOn(':getNotaryServerCPB')
     doFirst {
         jvmArgs '--add-opens', 'java.base/java.lang=ALL-UNNAMED',
                 '--add-opens', 'java.base/java.lang.invoke=ALL-UNNAMED',


### PR DESCRIPTION
So "apply" wasn't the correct thing to do. As the CSDE config is being defined in the all projects block, apply was duplicating that task registration onto the contracts & workflows submodules. This resulted in a given task being invoked 3 times.
Found that we can depend on the root task by including the colon, which acts like a path, so this now reads as workflows tests depdends on the root task "getNotaryServerCPB"

Evidence of task only being invoked once:
<img width="1585" alt="Screenshot 2023-08-30 at 11 44 17" src="https://github.com/corda/CSDE-cordapp-template-kotlin/assets/92731849/780f0262-bcbc-45d5-9105-b2c8553e164c">

Regpack run: https://ci02.dev.r3.com/job/QA/job/Craft_Tests/job/qa-regpack-csde/job/main/407
